### PR TITLE
Build image from binary image release including /usr filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.bin
+*.tar
+*-rootfs
+*.docker-image

--- a/rootfs.sh
+++ b/rootfs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -x
+
+echo ${1}
+
+export PART_9_OFFSET=$(( 512 * $(sfdisk -l -uS ${1}-image.bin | grep bin9 | awk '{ print $2 }')))
+export PART_3_OFFSET=$(( 512 * $(sfdisk -l -uS ${1}-image.bin | grep bin3 | awk '{ print $2 }')))
+echo $PART_9_OFFSET
+echo $PART_3_OFFSET
+
+mkdir -p ${1}-rootfs
+
+mount -o ro,loop,offset=${PART_9_OFFSET} -t auto ${1}-image.bin ${1}-rootfs
+mount -o ro,loop,offset=${PART_3_OFFSET} -t auto ${1}-image.bin ${1}-rootfs/usr


### PR DESCRIPTION
Hi @moul,

when I created an image using your Makefile it did not include the /usr filesystem and was not able to boot because the /sbin/init is a symlinc to /usr/lib/systemd/systemd which was missing.

I'm sure that is not perfect ( as I am very new to scaleway) and there is probably more to do but at least I was able to boot the instance and ssh into it if I add a cloud-config with my public key during the image creation with my version of scaleway-coreos  here: https://github.com/cornelius-keller/scaleway-coreos .

Open issues are:
- Coreos is waiting for a disk labeled OEM to be mounted at /usr/share/oem , containing the cloud-config.yml . Putting the file there during image creation provides a cloud-config and lets me login into the instance, but coreos is waiting for the device to be  mounted anyways.
- There must be a better and more generic solution for the coudconfig. Like it is now everybody has to build a custom version of this image containing the custom cloud config.
- I had a quick look into the makefiles and I'm sure there are a lot of other scaleway specific customizations to make this work really smoothly.
